### PR TITLE
Removing initial Friendlinks

### DIFF
--- a/grav-site/user/pages/04.sponsors/links.md
+++ b/grav-site/user/pages/04.sponsors/links.md
@@ -13,16 +13,7 @@ links:
 friendlinks:
   - text: Paypal
     url: "#"
-  - text: Patreon
-    url: "https://www.patreon.com/user?u=11040532"
-  - text: Twitch
-    url: "https://www.twitch.tv/thetridentproject"
-  - text: Liberapay
-    url: "https://en.liberapay.com/~52979"
-  - text: Indigogo
-    url: "https://www.indiegogo.com/individuals/18662200"
-  - text: Gab
-    url: "https://gab.ai/ProjectTrident"                
+          
 ---
 
 For information about Enterprise-level sponsorships, please contact the [Project Trident Core Team](mailto:core@project-trident.org).


### PR DESCRIPTION
Since the accounts aren't set up being being claimed, lets put announcing them on hold. We can add them one at a time and use that as a way to have a news announcement for each one.  We can trickle one out every couple weeks or so. So there is a steady stream of news of some variety.